### PR TITLE
Support pytorch1.11

### DIFF
--- a/configs/config_rodnet_cdc_win16.py
+++ b/configs/config_rodnet_cdc_win16.py
@@ -18,7 +18,7 @@ dataset_cfg = dict(
     ),
     demo=dict(
         subdir='demo',
-        seqs=[],
+        # seqs=[],
     ),
 )
 

--- a/rodnet/datasets/CRDataset.py
+++ b/rodnet/datasets/CRDataset.py
@@ -2,6 +2,8 @@ import os
 import time
 import random
 import pickle
+import traceback
+
 import numpy as np
 from tqdm import tqdm
 
@@ -165,6 +167,7 @@ class CRDataset(data.Dataset):
             data_dict['end_frame'] = data_id + self.win_size * self.step - 1
 
         except:
+            print(f"\033[1;36m {traceback.format_exc()}\033[0m")
             # in case load npy fail
             data_dict['status'] = False
             if not os.path.exists('./tmp'):

--- a/rodnet/ops/dcn/src/deform_conv_2d_cuda_kernel.cu
+++ b/rodnet/ops/dcn/src/deform_conv_2d_cuda_kernel.cu
@@ -62,6 +62,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAStream.h>
 #include <THC/THCAtomics.cuh>
 #include <stdio.h>
 #include <math.h>
@@ -262,7 +263,7 @@ void deformable_im2col(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *data_col_ = data_col.data<scalar_t>();
 
-        deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_im_, data_offset_, height, width, ksize_h, ksize_w,
             pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
             channel_per_deformable_group, parallel_imgs, channels, deformable_group,
@@ -356,7 +357,7 @@ void deformable_col2im(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *grad_im_ = grad_im.data<scalar_t>();
 
-        deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_offset_, channels, height, width, ksize_h,
             ksize_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -455,7 +456,7 @@ void deformable_col2im_coord(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *grad_offset_ = grad_offset.data<scalar_t>();
 
-        deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_im_, data_offset_, channels, height, width,
             ksize_h, ksize_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -785,7 +786,7 @@ void modulated_deformable_im2col_cuda(
         const scalar_t *data_mask_ = data_mask.data<scalar_t>();
         scalar_t *data_col_ = data_col.data<scalar_t>();
 
-        modulated_deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        modulated_deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_im_, data_offset_, data_mask_, height_im, width_im, kernel_h, kenerl_w,
             pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, channel_per_deformable_group,
             batch_size, channels, deformable_group, height_col, width_col, data_col_);
@@ -817,7 +818,7 @@ void modulated_deformable_col2im_cuda(
         const scalar_t *data_mask_ = data_mask.data<scalar_t>();
         scalar_t *grad_im_ = grad_im.data<scalar_t>();
 
-        modulated_deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        modulated_deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_offset_, data_mask_, channels, height_im, width_im,
             kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -852,7 +853,7 @@ void modulated_deformable_col2im_coord_cuda(
         scalar_t *grad_offset_ = grad_offset.data<scalar_t>();
         scalar_t *grad_mask_ = grad_mask.data<scalar_t>();
 
-        modulated_deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        modulated_deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_im_, data_offset_, data_mask_, channels, height_im, width_im,
             kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,

--- a/rodnet/ops/dcn/src/deform_conv_3d_cuda_kernel.cu
+++ b/rodnet/ops/dcn/src/deform_conv_3d_cuda_kernel.cu
@@ -63,6 +63,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <THC/THCAtomics.cuh>
+#include <c10/cuda/CUDAStream.h>
 #include <stdio.h>
 #include <math.h>
 #include <float.h>
@@ -321,7 +322,7 @@ void deformable_im2col(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *data_col_ = data_col.data<scalar_t>();
 
-        deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_im_, data_offset_, time, height, width, ksize_t, ksize_h, ksize_w,
             pad_t, pad_h, pad_w, stride_t, stride_h, stride_w, dilation_t, dilation_h, dilation_w,
             channel_per_deformable_group, parallel_imgs, channels, deformable_group,
@@ -437,7 +438,7 @@ void deformable_col2im(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *grad_im_ = grad_im.data<scalar_t>();
 
-        deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_offset_, channels, time, height, width,
             ksize_t, ksize_h, ksize_w, pad_t, pad_h, pad_w, stride_t, stride_h, stride_w,
             dilation_t, dilation_h, dilation_w, channel_per_deformable_group,
@@ -560,7 +561,7 @@ void deformable_col2im_coord(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *grad_offset_ = grad_offset.data<scalar_t>();
 
-        deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_im_, data_offset_, channels, time, height, width,
             ksize_t, ksize_h, ksize_w, pad_t, pad_h, pad_w, stride_t, stride_h, stride_w,
             dilation_t, dilation_h, dilation_w, channel_per_deformable_group,
@@ -890,7 +891,7 @@ void modulated_deformable_im2col_cuda(
         const scalar_t *data_mask_ = data_mask.data<scalar_t>();
         scalar_t *data_col_ = data_col.data<scalar_t>();
 
-        modulated_deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        modulated_deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_im_, data_offset_, data_mask_, height_im, width_im, kernel_h, kenerl_w,
             pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, channel_per_deformable_group,
             batch_size, channels, deformable_group, height_col, width_col, data_col_);
@@ -922,7 +923,7 @@ void modulated_deformable_col2im_cuda(
         const scalar_t *data_mask_ = data_mask.data<scalar_t>();
         scalar_t *grad_im_ = grad_im.data<scalar_t>();
 
-        modulated_deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        modulated_deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_offset_, data_mask_, channels, height_im, width_im,
             kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -957,7 +958,7 @@ void modulated_deformable_col2im_coord_cuda(
         scalar_t *grad_offset_ = grad_offset.data<scalar_t>();
         scalar_t *grad_mask_ = grad_mask.data<scalar_t>();
 
-        modulated_deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        modulated_deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_im_, data_offset_, data_mask_, channels, height_im, width_im,
             kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,

--- a/rodnet/ops/dcn/src/deform_pool_2d_cuda.cpp
+++ b/rodnet/ops/dcn/src/deform_pool_2d_cuda.cpp
@@ -33,7 +33,7 @@ void deform_psroi_pooling_cuda_forward(
     at::Tensor top_count, const int no_trans, const float spatial_scale,
     const int output_dim, const int group_size, const int pooled_size,
     const int part_size, const int sample_per_part, const float trans_std) {
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
   at::DeviceGuard guard(input.device());
 
   const int batch = input.size(0);
@@ -59,8 +59,8 @@ void deform_psroi_pooling_cuda_backward(
     const int no_trans, const float spatial_scale, const int output_dim,
     const int group_size, const int pooled_size, const int part_size,
     const int sample_per_part, const float trans_std) {
-  AT_CHECK(out_grad.is_contiguous(), "out_grad tensor has to be contiguous");
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(out_grad.is_contiguous(), "out_grad tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
   at::DeviceGuard guard(input.device());
 
   const int batch = input.size(0);

--- a/rodnet/ops/dcn/src/deform_pool_2d_cuda_kernel.cu
+++ b/rodnet/ops/dcn/src/deform_pool_2d_cuda_kernel.cu
@@ -9,6 +9,7 @@
 // modify from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/cuda/deform_psroi_pooling_cuda.cu
 
 #include <ATen/ATen.h>
+#include <c10/cuda/CUDAStream.h>
 #include <THC/THCAtomics.cuh>
 #include <stdio.h>
 #include <math.h>
@@ -296,7 +297,7 @@ void DeformablePSROIPoolForward(const at::Tensor data,
         scalar_t *top_data = out.data<scalar_t>();
         scalar_t *top_count_data = top_count.data<scalar_t>();
 
-        DeformablePSROIPoolForwardKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        DeformablePSROIPoolForwardKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             count, bottom_data, (scalar_t)spatial_scale, channels, height, width, pooled_height, pooled_width,
             bottom_rois, bottom_trans, no_trans, (scalar_t)trans_std, sample_per_part, output_dim,
             group_size, part_size, num_classes, channels_each_class, top_data, top_count_data);
@@ -349,7 +350,7 @@ void DeformablePSROIPoolBackwardAcc(const at::Tensor out_grad,
         scalar_t *bottom_trans_diff = no_trans ? NULL : trans_grad.data<scalar_t>();
         const scalar_t *top_count_data = top_count.data<scalar_t>();
 
-        DeformablePSROIPoolBackwardAccKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        DeformablePSROIPoolBackwardAccKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             count, top_diff, top_count_data, num_rois, (scalar_t)spatial_scale, channels, height, width,
             pooled_height, pooled_width, output_dim, bottom_data_diff, bottom_trans_diff,
             bottom_data, bottom_rois, bottom_trans, no_trans, (scalar_t)trans_std, sample_per_part,

--- a/rodnet/ops/dcn/src/deform_pool_3d_cuda.cpp
+++ b/rodnet/ops/dcn/src/deform_pool_3d_cuda.cpp
@@ -33,7 +33,7 @@ void deform_psroi_pooling_cuda_forward(
     at::Tensor top_count, const int no_trans, const float spatial_scale,
     const int output_dim, const int group_size, const int pooled_size,
     const int part_size, const int sample_per_part, const float trans_std) {
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
   at::DeviceGuard guard(input.device());
 
   const int batch = input.size(0);
@@ -59,8 +59,8 @@ void deform_psroi_pooling_cuda_backward(
     const int no_trans, const float spatial_scale, const int output_dim,
     const int group_size, const int pooled_size, const int part_size,
     const int sample_per_part, const float trans_std) {
-  AT_CHECK(out_grad.is_contiguous(), "out_grad tensor has to be contiguous");
-  AT_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
+  TORCH_CHECK(out_grad.is_contiguous(), "out_grad tensor has to be contiguous");
+  TORCH_CHECK(input.is_contiguous(), "input tensor has to be contiguous");
   at::DeviceGuard guard(input.device());
 
   const int batch = input.size(0);

--- a/rodnet/ops/dcn/src/deform_pool_3d_cuda_kernel.cu
+++ b/rodnet/ops/dcn/src/deform_pool_3d_cuda_kernel.cu
@@ -9,6 +9,7 @@
 // modify from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/cuda/deform_psroi_pooling_cuda.cu
 
 #include <ATen/ATen.h>
+#include <c10/cuda/CUDAStream.h>
 #include <THC/THCAtomics.cuh>
 #include <stdio.h>
 #include <math.h>
@@ -296,7 +297,7 @@ void DeformablePSROIPoolForward(const at::Tensor data,
         scalar_t *top_data = out.data<scalar_t>();
         scalar_t *top_count_data = top_count.data<scalar_t>();
 
-        DeformablePSROIPoolForwardKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        DeformablePSROIPoolForwardKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             count, bottom_data, (scalar_t)spatial_scale, channels, height, width, pooled_height, pooled_width,
             bottom_rois, bottom_trans, no_trans, (scalar_t)trans_std, sample_per_part, output_dim,
             group_size, part_size, num_classes, channels_each_class, top_data, top_count_data);
@@ -349,7 +350,7 @@ void DeformablePSROIPoolBackwardAcc(const at::Tensor out_grad,
         scalar_t *bottom_trans_diff = no_trans ? NULL : trans_grad.data<scalar_t>();
         const scalar_t *top_count_data = top_count.data<scalar_t>();
 
-        DeformablePSROIPoolBackwardAccKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        DeformablePSROIPoolBackwardAccKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
             count, top_diff, top_count_data, num_rois, (scalar_t)spatial_scale, channels, height, width,
             pooled_height, pooled_width, output_dim, bottom_data_diff, bottom_trans_diff,
             bottom_data, bottom_rois, bottom_trans, no_trans, (scalar_t)trans_std, sample_per_part,

--- a/tools/test.py
+++ b/tools/test.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
 
     data_root = dataset_configs['data_root']
     if not args.demo:
-        seq_names = sorted(os.listdir(os.path.join(data_root, dataset_configs['test']['subdir'])))
+        seq_names = sorted(os.listdir(os.path.join(data_root, dataset_configs['train']['subdir'])))
     else:
         seq_names = sorted(os.listdir(os.path.join(data_root, dataset_configs['demo']['subdir'])))
     print(seq_names)
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     for subset in seq_names:
         print(subset)
         if not args.demo:
-            crdata_test = CRDataset(data_dir=args.data_dir, dataset=dataset, config_dict=config_dict, split='test',
+            crdata_test = CRDataset(data_dir=args.data_dir, dataset=dataset, config_dict=config_dict, split='train',
                                     noise_channel=args.use_noise_channel, subset=subset, is_random_chirp=False)
         else:
             crdata_test = CRDataset(data_dir=args.data_dir, dataset=dataset, config_dict=config_dict, split='demo',


### PR DESCRIPTION
- Given a demand of higher version pytorch(e.g. 1.11), some modification for the cuda code has proposed. Note that the lower version has not been tested, some errors may be met.
- When running the test.py, some warnings aren't clear , direct and confusing, so add the traceback module.
![image](https://user-images.githubusercontent.com/47175732/169532466-d6dba85a-b255-4dc7-b416-b913aded1ac5.png)
